### PR TITLE
Restructurizing CS-files

### DIFF
--- a/Voxel Tycoon Open Library/Buildings/VTOLBuildingUtils.cs
+++ b/Voxel Tycoon Open Library/Buildings/VTOLBuildingUtils.cs
@@ -5,7 +5,7 @@ using VoxelTycoon;
 using VoxelTycoon.Buildings;
 using VoxelTycoon.Game;
 
-namespace VTOL
+namespace VTOL.Buildings
 {
     /// <summary>
     /// Class with utility methods concerning buildings in Voxel Tycoon

--- a/Voxel Tycoon Open Library/Reflection/VTOLReflectionHelpers.cs
+++ b/Voxel Tycoon Open Library/Reflection/VTOLReflectionHelpers.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Reflection;
 
-namespace VTOL
+namespace VTOL.Reflection
 {
     /// <summary>
     /// Class with methods to help with reflection 

--- a/tests/VTOL.Tests/VTOLReflectionHelpersTests.cs
+++ b/tests/VTOL.Tests/VTOLReflectionHelpersTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using VTOL.Reflection;
 
 namespace VTOL
 {


### PR DESCRIPTION
As suggested in [this PR](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/pull/23), I restructured the CS-files.

Now each CS-file is in a folder containing all the CS-files part of a namespace.