### PR TITLE
Connection Filter System Fix

### DIFF
--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
@@ -14,20 +14,33 @@ namespace VTOL.StorageNetwork.ConnectionManager
 		private Lazy<List<PriorityConnectionFilter>> _connectionFilters = new Lazy<List<PriorityConnectionFilter>>();
 		private bool _isModified;
 
-		private List<PriorityConnectionFilter> ConnectionFilters => _connectionFilters.Value; 
+		private List<PriorityConnectionFilter> ConnectionFilters => _connectionFilters.Value;
 
 		/// <summary>
-		/// Registers a method which decides if a connection between two <see cref="StorageNetworkBuilding"/> should be allowed or not.
+		/// Registers a <see cref="IConnectionFilter"/> to the connection filter system.
 		/// </summary>
-		/// <param name="connectionFilter">The class which decides if a connection should be canceled or not.</param>
+		/// <typeparam name="TFilter">Type of class which holds the <see cref="IConnectionFilter"/> fucntionality.</typeparam>
 		/// <param name="priority">(Optional) The priority of the filter. Default value is 0.</param>
 		/// <exception cref="InvalidOperationException">When trying to register while the game is done loading.</exception>
 		/// <remarks>Filters with a higher priority will be executed after filters with a lower priority. Meaning the alterations made by a filter with a higher priority cannot be overwritten by a filter with a lower priority.</remarks>
-		public void RegisterConnectionFilter(IConnectionFilter connectionFilter, double priority = 0)
+		public void RegisterConnectionFilter<TFilter>(double priority = 0)
+			where TFilter : IConnectionFilter, new()
+		{
+			try
+			{
+				RegisterConnectionFilter(new TFilter(), priority);
+			}
+			catch (InvalidOperationException)
+			{
+				throw new InvalidOperationException($"You are not allowed to register after state OnGameStarting. The current state is {Vtol.GameState}.");
+			}
+		}
+
+		private void RegisterConnectionFilter(IConnectionFilter connectionFilter, double priority = 0)
 		{
 			if (Vtol.GameState > GameStates.OnGameStarting)
 			{
-				throw new InvalidOperationException($"You are not allowed to register after state OnGameStarting. The current state is {Vtol.GameState}.");
+				throw new InvalidOperationException();
 			}
 
 			PriorityConnectionFilter priorityListener = new PriorityConnectionFilter(connectionFilter, priority);

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
@@ -19,22 +19,13 @@ namespace VTOL.StorageNetwork.ConnectionManager
 		/// <summary>
 		/// Registers a <see cref="IConnectionFilter"/> to the connection filter system.
 		/// </summary>
-		/// <typeparam name="TFilter">Type of class which holds the <see cref="IConnectionFilter"/> fucntionality.</typeparam>
+		/// <typeparam name="TFilter">Type of class which holds the <see cref="IConnectionFilter"/> functionality.</typeparam>
 		/// <param name="priority">(Optional) The priority of the filter. Default value is 0.</param>
 		/// <exception cref="InvalidOperationException">When trying to register while the game is done loading.</exception>
 		/// <remarks>Filters with a higher priority will be executed after filters with a lower priority. Meaning the alterations made by a filter with a higher priority cannot be overwritten by a filter with a lower priority.</remarks>
 		public void RegisterConnectionFilter<TFilter>(double priority = 0)
-			where TFilter : IConnectionFilter, new()
-		{
-			try
-			{
-				RegisterConnectionFilter(new TFilter(), priority);
-			}
-			catch (InvalidOperationException)
-			{
-				throw new InvalidOperationException($"You are not allowed to register after state OnGameStarting. The current state is {Vtol.GameState}.");
-			}
-		}
+			where TFilter : IConnectionFilter, new() 
+			=> RegisterConnectionFilter(new TFilter(), priority);
 
 		private void RegisterConnectionFilter(IConnectionFilter connectionFilter, double priority = 0)
 		{

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using VoxelTycoon;
 using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// This class provides methods to allow for adjusting Storage Network connections.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/IConnectionFilter.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/IConnectionFilter.cs
@@ -1,6 +1,6 @@
 ﻿using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// A class which is used to build a connection filter should implement this interface.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
@@ -2,12 +2,12 @@
 using HarmonyLib;
 using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// This class is used to control which <see cref="StorageNetworkBuilding"/> can be connected with eachother.
 	/// Voxel Tycoon only dictates that certain buildings can connect with eachother based on their type. With this patch a system is introduced where it is also possible to filter connections based on custom logic.
-	/// Filters are classes implementing <see cref="IConnectionFilter"/>, therefor they have the functionality to allow or disallow a connection between two <see cref="StorageNetworkBuilding"/>. 
+	/// Filters are classes implementing <see cref="IConnectionFilter"/>, and have the functionality to allow or disallow a connection between two <see cref="StorageNetworkBuilding"/>. 
 	/// These filter classes are made by the user and can be registered with <see cref="ConnectionController.RegisterConnectionFilter(IConnectionFilter, double)"/>.
 	/// Every time a new <see cref="StorageNetworkBuilding"/> is placed, Voxel Tycoon will update the Storage Network, but only for the <see cref="StorageNetworkBuilding"/> which are in range of the placed building.
 	/// To update the Storage Network, Voxel Tycoon will use <see cref="StorageBuildingManager.FindSiblings(StorageNetworkBuilding)"/> for each <see cref="StorageNetworkBuilding"/> that needs an update and returns a list with all potential connections.
@@ -19,8 +19,7 @@ namespace VTOL.StorageNetwork
 	{
 		static void Postfix(StorageNetworkBuilding building) 
 		{
-			if (building.Id == 0 || 
-				//If building.Id is 0, this means the building is still a ghost (building mode), and the storage network doesnt need to update. Unfortunately because of an inefficiency in Voxel Tycoon it is constantly updating the network. This way we prevent the filters from happening while the building is still a ghost.
+			if (!building.IsBuilt ||
 				!ConnectionController.Current.GetConnectionFilters(out IList<PriorityConnectionFilter> connectionFilters))
 			{
 				return;

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
@@ -8,7 +8,7 @@ namespace VTOL.StorageNetwork.ConnectionManager
 	/// This class is used to control which <see cref="StorageNetworkBuilding"/> can be connected with eachother.
 	/// Voxel Tycoon only dictates that certain buildings can connect with eachother based on their type. With this patch a system is introduced where it is also possible to filter connections based on custom logic.
 	/// Filters are classes implementing <see cref="IConnectionFilter"/>, and have the functionality to allow or disallow a connection between two <see cref="StorageNetworkBuilding"/>. 
-	/// These filter classes are made by the user and can be registered with <see cref="ConnectionController.RegisterConnectionFilter(IConnectionFilter, double)"/>.
+	/// These filter classes are made by the user and can be registered with <see cref="ConnectionController.RegisterConnectionFilter{TFilter}(double)"/>.
 	/// Every time a new <see cref="StorageNetworkBuilding"/> is placed, Voxel Tycoon will update the Storage Network, but only for the <see cref="StorageNetworkBuilding"/> which are in range of the placed building.
 	/// To update the Storage Network, Voxel Tycoon will use <see cref="StorageBuildingManager.FindSiblings(StorageNetworkBuilding)"/> for each <see cref="StorageNetworkBuilding"/> that needs an update and returns a list with all potential connections.
 	/// Before this list with potential connections is returned, <see cref="InvalidateSiblingsPatch"/> allows all filters to cycle through this list and decide if a connection should be allowed or not.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
@@ -6,7 +6,7 @@ namespace VTOL.StorageNetwork.ConnectionManager
 	/// <summary>
 	/// This patch makes sure that a <see cref="StorageNetworkBuilding"/> updates it's Storage Network in the same frame it has been built.
 	/// <para>After some investigating we found that a <see cref="StorageNetworkBuilding"/> is not updating it's Storage Network in the frame it has been build. Instead it would only update whenever another <see cref="StorageNetworkBuilding"/> is build within range.
-	/// For the Connection Filters to work correctly it is necessary that the network is updated after building too. This patch makes sure this happens.</para>
+	/// For the Connection Filters to update immediately it is necessary that the network is updated in the same frame the building built. This patch makes sure the built building is marked as dirty, so the Storage Network is updating its connections.</para>
 	/// </summary>
 	[HarmonyPatch(typeof(StorageNetworkBuilding))]
 	[HarmonyPatch("OnBuilt")]

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
@@ -6,7 +6,8 @@ namespace VTOL.StorageNetwork.ConnectionManager
 	/// <summary>
 	/// This patch makes sure that a <see cref="StorageNetworkBuilding"/> updates it's Storage Network in the same frame it has been built.
 	/// <para>After some investigating we found that a <see cref="StorageNetworkBuilding"/> is not updating it's Storage Network in the frame it has been build. Instead it would only update whenever another <see cref="StorageNetworkBuilding"/> is build within range.
-	/// For the Connection Filters to update immediately it is necessary that the network is updated in the same frame the building built. This patch makes sure the built building is marked as dirty, so the Storage Network is updating its connections.</para>
+	/// For the Connection Filters to update immediately it is necessary that the network is updated in the same frame the building is built. This patch makes sure the built building is marked as dirty, 
+	/// so the Storage Network is updating its connections in the same frame.</para>
 	/// </summary>
 	[HarmonyPatch(typeof(StorageNetworkBuilding))]
 	[HarmonyPatch("OnBuilt")]

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using VoxelTycoon.Buildings;
+
+namespace VTOL.StorageNetwork.ConnectionManager
+{
+	/// <summary>
+	/// This patch makes sure that a <see cref="StorageNetworkBuilding"/> updates it's Storage Network in the same frame it has been built.
+	/// <para>After some investigating we found that a <see cref="StorageNetworkBuilding"/> is not updating it's Storage Network in the frame it has been build. Instead it would only update whenever another <see cref="StorageNetworkBuilding"/> is build within range.
+	/// For the Connection Filters to work correctly it is necessary that the network is updated after building too. This patch makes sure this happens.</para>
+	/// </summary>
+	[HarmonyPatch(typeof(StorageNetworkBuilding))]
+	[HarmonyPatch("OnBuilt")]
+	internal static class MarkBuildingDirtyPatch
+	{
+		static bool Prefix(StorageNetworkBuilding __instance)
+		{
+			__instance.MarkSiblingsDirty();
+
+			return true;
+		}
+	}
+}

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnection.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnection.cs
@@ -1,6 +1,6 @@
 ﻿using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// Class used by <see cref="PotentialConnectionArgs"/> to store each building detected. Also, this class keeps track of a connection should be canceled once all filters have been executed.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnectionArgs.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnectionArgs.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using VoxelTycoon.Buildings;
 using VTOL.Debugging;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// This class is used to collect all the Siblings found by <see cref="VoxelTycoon.Buildings.StorageBuildingManager.FindSiblings(StorageNetworkBuilding)"/>

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PriorityConnectionFilter.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PriorityConnectionFilter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// When a connection filter is registered, it is stored in an instance of <see cref="PriorityConnectionFilter"/>. <see cref="PriorityConnectionFilter"/> is used to sort every registered filter based on their priority.


### PR DESCRIPTION
### ConnectionController
[(ConnectionController.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/ConnectionController.cs)

- Assigned new namespace `VTOL.StorageNetwork.ConnectionManager`.

Changed `RegisterConnectionFilter()` so it is no longer required to register a `IConnectionFilter` with `RegisterConnectionFilter(new IConnectionFilter, priority)`. Instead you can just give the type of the class you want to register:

`RegisterConnectionFilter<TFilter>(double priority = 0);`

This new method will use the old method creating a new instance of `TFilter`.

- Changed the original `RegisterConnectionFilter`-method to private
- Removed summary from original `RegisterConnectionFilter`-method
- Added a new public `RegisterConnectionFilter`-method
- Added summary to the new `RegisterConnectionFilter`-method

### IConnectionFilter

[(IConnectionFilter.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/IConnectionFilter.cs)

- Assigned new namespace `VTOL.StorageNetwork.ConnectionManager`.

### InvalidateSiblingsPatch

[(InvalidateSiblingsPatch.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs)

- Assigned new namespace `VTOL.StorageNetwork.ConnectionManager`.
- Changed some wording in the summary
- Turned out there was a `boolean` tracking if a building was built: `Building.IsBuilt`. Using this boolean to check if a building is built instead of using `Building.Id`.
- Updated summary so it complies with the new `ConnectionController.RegisterConnectionFilter`-method.

### MarkBuildingDirtyPatch (new)

[(MarkBuildingDirtyPatch.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs)

It turned out that when a StorageNetworkBuilding was built, the building itself would not update it's Storage Network, only the buildings around it within range did. For the Connection Filter system to work correctly we required the newly built building to update it's Storage Network too.

- Added a prefix to `StorageNetworkBuilding.OnBuilt()` to use `MarkSiblingsDirty()` for the current instance. This will make sure the Storage Network is also updated for the building that has been built in the current frame.

### PotentialConnection

[(PotentialConnection.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/PotentialConnection.cs)

- Assigned new namespace `VTOL.StorageNetwork.ConnectionManager`.

### PotentialConnectionArgs

[(PotentialConnectionArgs.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/PotentialConnectionArgs.cs)

- Assigned new namespace `VTOL.StorageNetwork.ConnectionManager`.

### PriorityConnectionFilter

[(PriorityConnectionFilter.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/2e8b76d64bbd172d27ac46687337e1c39efa2b24/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/PriorityConnectionFilter.cs)

### Folders

- Created a folder for the new namespace