### PR TITLE
Connection filter system tests

### DIFF
--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/ConnectionController.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using VoxelTycoon;
 using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// This class provides methods to allow for adjusting Storage Network connections.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/IConnectionFilter.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/IConnectionFilter.cs
@@ -1,6 +1,6 @@
 ﻿using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// A class which is used to build a connection filter should implement this interface.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
@@ -17,7 +17,7 @@ namespace VTOL.StorageNetwork.ConnectionManager
 	[HarmonyPatch("FindSiblings")]
 	internal static class InvalidateSiblingsPatch
 	{
-		static void Postfix(StorageNetworkBuilding building) 
+		internal static void Postfix(StorageNetworkBuilding building) 
 		{
 			if (!building.IsBuilt ||
 				!ConnectionController.Current.GetConnectionFilters(out IList<PriorityConnectionFilter> connectionFilters))

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.cs
@@ -2,12 +2,12 @@
 using HarmonyLib;
 using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// This class is used to control which <see cref="StorageNetworkBuilding"/> can be connected with eachother.
 	/// Voxel Tycoon only dictates that certain buildings can connect with eachother based on their type. With this patch a system is introduced where it is also possible to filter connections based on custom logic.
-	/// Filters are classes implementing <see cref="IConnectionFilter"/>, therefor they have the functionality to allow or disallow a connection between two <see cref="StorageNetworkBuilding"/>. 
+	/// Filters are classes implementing <see cref="IConnectionFilter"/>, and have the functionality to allow or disallow a connection between two <see cref="StorageNetworkBuilding"/>. 
 	/// These filter classes are made by the user and can be registered with <see cref="ConnectionController.RegisterConnectionFilter(IConnectionFilter, double)"/>.
 	/// Every time a new <see cref="StorageNetworkBuilding"/> is placed, Voxel Tycoon will update the Storage Network, but only for the <see cref="StorageNetworkBuilding"/> which are in range of the placed building.
 	/// To update the Storage Network, Voxel Tycoon will use <see cref="StorageBuildingManager.FindSiblings(StorageNetworkBuilding)"/> for each <see cref="StorageNetworkBuilding"/> that needs an update and returns a list with all potential connections.
@@ -19,8 +19,7 @@ namespace VTOL.StorageNetwork
 	{
 		static void Postfix(StorageNetworkBuilding building) 
 		{
-			if (building.Id == 0 || 
-				//If building.Id is 0, this means the building is still a ghost (building mode), and the storage network doesnt need to update. Unfortunately because of an inefficiency in Voxel Tycoon it is constantly updating the network. This way we prevent the filters from happening while the building is still a ghost.
+			if (!building.IsBuilt ||
 				!ConnectionController.Current.GetConnectionFilters(out IList<PriorityConnectionFilter> connectionFilters))
 			{
 				return;

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/MarkBuildingDirtyPatch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using VoxelTycoon.Buildings;
+
+namespace VTOL.StorageNetwork.ConnectionManager
+{
+	/// <summary>
+	/// This patch makes sure that a <see cref="StorageNetworkBuilding"/> updates it's Storage Network in the same frame it has been built.
+	/// <para>After some investigating we found that a <see cref="StorageNetworkBuilding"/> is not updating it's Storage Network in the frame it has been build. Instead it would only update whenever another <see cref="StorageNetworkBuilding"/> is build within range.
+	/// For the Connection Filters to work correctly it is necessary that the network is updated after building too. This patch makes sure this happens.</para>
+	/// </summary>
+	[HarmonyPatch(typeof(StorageNetworkBuilding))]
+	[HarmonyPatch("OnBuilt")]
+	internal static class MarkBuildingDirtyPatch
+	{
+		static bool Prefix(StorageNetworkBuilding __instance)
+		{
+			__instance.MarkSiblingsDirty();
+
+			return true;
+		}
+	}
+}

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnection.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnection.cs
@@ -1,6 +1,6 @@
 ﻿using VoxelTycoon.Buildings;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// Class used by <see cref="PotentialConnectionArgs"/> to store each building detected. Also, this class keeps track of a connection should be canceled once all filters have been executed.

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnectionArgs.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PotentialConnectionArgs.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using VoxelTycoon.Buildings;
 using VTOL.Debugging;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// This class is used to collect all the Siblings found by <see cref="VoxelTycoon.Buildings.StorageBuildingManager.FindSiblings(StorageNetworkBuilding)"/>

--- a/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PriorityConnectionFilter.cs
+++ b/Voxel Tycoon Open Library/StorageNetwork/ConnectionManager/PriorityConnectionFilter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace VTOL.StorageNetwork
+namespace VTOL.StorageNetwork.ConnectionManager
 {
 	/// <summary>
 	/// When a connection filter is registered, it is stored in an instance of <see cref="PriorityConnectionFilter"/>. <see cref="PriorityConnectionFilter"/> is used to sort every registered filter based on their priority.

--- a/Voxel Tycoon Open Library/Vtol.cs
+++ b/Voxel Tycoon Open Library/Vtol.cs
@@ -19,7 +19,7 @@ namespace VTOL
 		/// The GameState Voxel Tycoon is currently in.
 		/// </summary>
 		/// <remarks>The game states are based on the virtual methods provided in <see cref="VoxelTycoon.Modding.Mod"/>.</remarks>
-		public static GameStates GameState { get; private set; }
+		public static GameStates GameState { get; internal set; }
 
 		/// <summary>
 		/// Method called when this mod is being registered. This is before all mods are available.

--- a/tests/VTOL.Tests/StorageNetwork/ConnectionManager/ConnectionControllerTests.cs
+++ b/tests/VTOL.Tests/StorageNetwork/ConnectionManager/ConnectionControllerTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace VTOL.StorageNetwork.ConnectionManager
+{
+	/// <summary>
+	/// Responsible for containig different testing functionality with respect
+	/// to the <see cref="ConnectionController"/> class.
+	/// </summary>
+	internal class ConnectionControllerTests
+	{
+
+		/*
+		 * Test TODOs:
+		 * - Priority Ordering testen
+		 * - Patch building testen
+		 */
+
+		[Test]
+		public void X() { }
+
+	}
+}

--- a/tests/VTOL.Tests/StorageNetwork/ConnectionManager/InvalidateSiblingsPatchTests.cs
+++ b/tests/VTOL.Tests/StorageNetwork/ConnectionManager/InvalidateSiblingsPatchTests.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using VoxelTycoon;
+using VoxelTycoon.Buildings;
+using NUnit.Framework;
+using VTOL.Testing;
+
+using SDebug = System.Diagnostics.Debug;
+
+namespace VTOL.StorageNetwork.ConnectionManager
+{
+	internal class InvalidateSiblingsPatchTests
+	{
+		[SetUp]
+		public void InstantiateLazyManagerClasses()
+		{
+			TestHelpers.CreateLazyManagerMockObject<ConnectionController>();
+		}
+		
+		[SetUp]
+		public void InstantiateConnectionController()
+		{
+			// We cannot call the default constructor because it will try to
+			// create a Unity GameObject, while we run the tests outside of
+			// the unity environment.
+			//
+			// So this will manually create a new instance without
+			// the constructor and assigns all its required fields.
+			Type controllerType = typeof(ConnectionController);
+
+			ConnectionController controller = 
+				(ConnectionController) FormatterServices.GetUninitializedObject(controllerType);
+
+			// Assign the different fields which are accessed by the to be tested methods,
+			// these are normally set in the constructor.
+			FieldInfo connectionFilterField = controllerType.GetField(
+				"_connectionFilters",
+				BindingFlags.Instance | BindingFlags.NonPublic
+			);
+			SDebug.Assert(connectionFilterField != null);
+			connectionFilterField.SetValue(controller, new Lazy<List<PriorityConnectionFilter>>());
+
+			// Now we assign our custom object to the LazyManager instance value.
+			Type lazyManagerType = typeof(LazyManager<ConnectionController>);
+			FieldInfo singletonField = lazyManagerType.GetField(
+				"_current",
+				BindingFlags.Static | BindingFlags.NonPublic
+			);
+			SDebug.Assert(singletonField != null);
+			singletonField.SetValue(null, controller);
+		}
+
+		[SetUp]
+		public void InstantiateStorageBuildingManager()
+		{
+			Type managerType = typeof(StorageBuildingManager);
+
+			StorageBuildingManager storageBuildingManager = 
+				(StorageBuildingManager) FormatterServices.GetUninitializedObject(managerType);
+
+			MethodInfo[] methods = managerType.GetMethods();
+
+			foreach (MethodInfo method in methods)
+			{
+				Console.WriteLine(method.Name);
+			}
+
+			FieldInfo[] fields = managerType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance);
+
+			foreach (FieldInfo field in fields)
+			{
+				Console.WriteLine(field.Name);
+			}
+
+			FieldInfo findSiblingsResultField = managerType.GetField($"<{nameof(storageBuildingManager.FindSiblingsResult)}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+
+			SDebug.Assert(findSiblingsResultField != null);
+
+			findSiblingsResultField.SetValue(storageBuildingManager, new List<StorageBuildingSibling>());
+
+			Type lazyManagerType = typeof(LazyManager<StorageBuildingManager>);
+			FieldInfo singletonField = lazyManagerType.GetField(
+				"_current",
+				BindingFlags.Static | BindingFlags.NonPublic
+			);
+			SDebug.Assert(singletonField != null);
+			singletonField.SetValue(null, storageBuildingManager);
+		}
+
+		[Test]
+		public void Postfix_Ignores_WhenBuildingInGhostMode() 
+		{
+			// Arrange
+			StorageNetworkBuilding testBuilding = new Mine { IsBuilt = false };
+			
+			SDebug.Assert(ConnectionController.Current != null);
+			ConnectionController.Current.RegisterConnectionFilter(new FailFilter());
+
+			// Act
+			InvalidateSiblingsPatch.Postfix(testBuilding);
+
+			// Assert
+			/* FailFilter fails the test when its code is executed instead. */
+		}
+		[Test]
+		public void Postfix_ExecutesFilters_WhenBuildingIsBuilt()
+		{
+			// Arrange
+			StorageNetworkBuilding testBuilding = new Mine { IsBuilt = true };
+			SuccessFilter successFilter = new SuccessFilter();
+
+			SDebug.Assert(ConnectionController.Current != null);
+			ConnectionController.Current.RegisterConnectionFilter(successFilter);
+
+			// Act
+			InvalidateSiblingsPatch.Postfix(testBuilding);
+
+			// Assert
+			Assert.AreEqual(successFilter.CalledRelevant, 1);
+			Assert.AreEqual(successFilter.CalledConnect, 1);
+		}
+
+
+		internal class FailFilter : IConnectionFilter {
+
+			/// <inheritdoc />
+			public bool IsRelevant(StorageNetworkBuilding source)
+			{
+				Assert.Fail("Called IsRelevant in Filter class.");
+				return false;
+			}
+
+			/// <inheritdoc />
+			public void OnConnect(PotentialConnectionArgs potentialConnectionArgs)
+			{
+				Assert.Fail("Called OnConnect in Filter class.");
+			}
+		}
+
+		internal class SuccessFilter : IConnectionFilter
+		{
+			public int CalledRelevant { get; private set; }
+			public int CalledConnect { get; private set; }
+
+			/// <inheritdoc />
+			public bool IsRelevant(StorageNetworkBuilding source)
+			{
+				CalledRelevant++;
+				return true;
+			}
+
+			/// <inheritdoc />
+			public void OnConnect(PotentialConnectionArgs potentialConnectionArgs)
+			{
+				CalledConnect++;
+			}
+		}
+
+	}
+}

--- a/tests/VTOL.Tests/Testing/TestHelpers.cs
+++ b/tests/VTOL.Tests/Testing/TestHelpers.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using VoxelTycoon;
+
+using SDebug = System.Diagnostics.Debug;
+
+namespace VTOL.Testing
+{
+	/// <summary>
+	/// This class contains methods which help with setting up a testing environment.
+	/// </summary>
+	internal static class TestHelpers
+	{
+		/// <summary>
+		/// Creates a <see cref="LazyManager{T}"/> without using the constructor and sets the required <see cref="LazyManager{T}.Current"/>
+		/// field with an instance of type T.
+		/// </summary>
+		/// <typeparam name="T">Type of object of which a <see cref="LazyManager{T}"/> object should be created.</typeparam>
+		/// <returns>Returns an uninitialized object of type T</returns>
+		/// <remarks>We cannot call the default constructor because it will try to create a Unity GameObject,
+		/// while we run the tests outside of the unity environment</remarks>
+		public static T CreateLazyManagerMockObject<T>() where T : LazyManager<T>, new()
+		{
+			Type mockType = typeof(T);
+			Type lazyManagerType = typeof(LazyManager<T>);
+
+			T mockObject = (T) FormatterServices.GetUninitializedObject(mockType);
+
+			FieldInfo singletonField = lazyManagerType.GetField("_current", BindingFlags.Static | BindingFlags.NonPublic);
+			SDebug.Assert(singletonField != null);
+			singletonField.SetValue(null, mockObject);
+
+			return mockObject;
+		}
+	}
+}

--- a/tests/VTOL.Tests/VTOL.Tests.csproj
+++ b/tests/VTOL.Tests/VTOL.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />


### PR DESCRIPTION
### InvalidateSiblingsPatch

[(InvalidateSiblingsPatch.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/fdc2810dd9e2fa3374fefa2d3da036e3cf6ef758/Voxel%20Tycoon%20Open%20Library/StorageNetwork/ConnectionManager/InvalidateSiblingsPatch.csl)

- Changed the access modifier of the `Postfix`-method to `internal`, so test methods can reach it.

### Vtol

[(Vtol.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/fdc2810dd9e2fa3374fefa2d3da036e3cf6ef758/Voxel%20Tycoon%20Open%20Library/Vtol.cs)

- Changed the access modifier of the `GameState`-property to `internal`, so test methods can reach it.

### ConnectionControllerTests (new)

[(ConnectionControllerTests,cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/fdc2810dd9e2fa3374fefa2d3da036e3cf6ef758/tests/VTOL.Tests/StorageNetwork/ConnectionManager/ConnectionControllerTests.cs)

- Added class which will hold all the tests for the `ConnectionController`-class

### InvalidateSiblingsPatchTests (new)

[(InvalidateSiblingsPatchTests.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/fdc2810dd9e2fa3374fefa2d3da036e3cf6ef758/tests/VTOL.Tests/StorageNetwork/ConnectionManager/InvalidateSiblingsPatchTests.cs)

- Added class which will hold all the tests for the `InvalidateSiblingsPatch`-class

### TestHelpers

[(TestHelpers.cs)](https://github.com/voxeltycoon-community/voxel-tycoon-open-library/blob/fdc2810dd9e2fa3374fefa2d3da036e3cf6ef758/tests/VTOL.Tests/Testing/TestHelpers.cs)

- Added class which will have methods to help with creating a working test environment.
- Added `CreateLazyManagerMockObject`-method

### Folders

- Added new `VTOL.Test`-namespace
- Added Testing folder